### PR TITLE
add Analytics Object

### DIFF
--- a/types.go
+++ b/types.go
@@ -39,20 +39,21 @@ type Trending struct {
 
 // Data contains all the fields in a data response from the Giphy API
 type Data struct {
-	Type             string `json:"type"`
-	ID               string `json:"id"`
-	URL              string `json:"url"`
-	BitlyGifURL      string `json:"bitly_gif_url"`
-	BitlyURL         string `json:"bitly_url"`
-	EmbedURL         string `json:"embed_url"`
-	Username         string `json:"username"`
-	Source           string `json:"source"`
-	Rating           string `json:"rating"`
-	Caption          string `json:"caption"`
-	ContentURL       string `json:"content_url"`
-	ImportDatetime   string `json:"import_datetime"`
-	TrendingDatetime string `json:"trending_datetime"`
-	Images           Images `json:"images"`
+	Type             string    `json:"type"`
+	ID               string    `json:"id"`
+	URL              string    `json:"url"`
+	BitlyGifURL      string    `json:"bitly_gif_url"`
+	BitlyURL         string    `json:"bitly_url"`
+	EmbedURL         string    `json:"embed_url"`
+	Username         string    `json:"username"`
+	Source           string    `json:"source"`
+	Rating           string    `json:"rating"`
+	Caption          string    `json:"caption"`
+	ContentURL       string    `json:"content_url"`
+	ImportDatetime   string    `json:"import_datetime"`
+	TrendingDatetime string    `json:"trending_datetime"`
+	Images           Images    `json:"images"`
+	Analytics        Analytics `json:"analytics"`
 }
 
 // MediaURL points directly to GIF image on media.giphy.com
@@ -125,4 +126,14 @@ type Pagination struct {
 type Meta struct {
 	Status int    `json:"status"`
 	Msg    string `json:"msg"`
+}
+
+// Analytics urls to send back to giphy
+type ActionUrl struct {
+	URL string `json:"url"`
+}
+type Analytics struct {
+	Onload  ActionUrl  `json:"onload"`
+	Onclick ActionUrl `json:"onclick"`
+	Onsent  ActionUrl  `json:"onsent"`
 }

--- a/types.go
+++ b/types.go
@@ -128,12 +128,14 @@ type Meta struct {
 	Msg    string `json:"msg"`
 }
 
-// Analytics urls to send back to giphy
-type ActionUrl struct {
+// ActionURL contains a pingback URL for an action such as SEEN, CLICK or SENT
+type ActionURL struct {
 	URL string `json:"url"`
 }
+
+// Analytics represents the analytics section in a Giphy API response
 type Analytics struct {
-	Onload  ActionUrl  `json:"onload"`
-	Onclick ActionUrl `json:"onclick"`
-	Onsent  ActionUrl  `json:"onsent"`
+	Onload  ActionURL `json:"onload"`
+	Onclick ActionURL `json:"onclick"`
+	Onsent  ActionURL `json:"onsent"`
 }


### PR DESCRIPTION
add analytics object, used to send action event back to giphy. If you merged this pr, please release a new tag.